### PR TITLE
Compiler Hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 *.exe
 *.out
 *.app
+
+# Files
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 CC = gcc
 COMPILE_TIME_CHECKS = -Wall -Wextra -Wformat=2 -Wconversion -Wsign-conversion -Wtrampolines -Werror
 RUN_TIME_CHECKS = -D_FORTIFY_SOURCE=3 -O2 -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fPIE -pie
-CFLAGS = $(COMPILE_TIME_CHECKS) $(RUN_TIME_CHECKS) -pedantic
+CUSTOM_CHECKS = -fcf-protection=full -fharden-compares -fsanitize=address -fsanitize=leak -fsanitize=undefined
+CFLAGS = $(COMPILE_TIME_CHECKS) $(RUN_TIME_CHECKS) $(CUSTOM_CHECKS) -pedantic -Wformat -Wformat-security -Wshadow -Wundef
 all:
 	$(CC) $(CFLAGS) -lX11 -pthread mouse.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 COMPILE_TIME_CHECKS = -Wall -Wextra -Wformat=2 -Wconversion -Wsign-conversion -Wtrampolines -Werror
 RUN_TIME_CHECKS = -D_FORTIFY_SOURCE=3 -O2 -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fPIE -pie
-CFLAGS = $(COMPILE_TIME_CHECKS) $(RUN_TIME_CHECKS)
+CFLAGS = $(COMPILE_TIME_CHECKS) $(RUN_TIME_CHECKS) -pedantic
 all:
 	$(CC) $(CFLAGS) -lX11 -pthread mouse.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
+CC = gcc
+COMPILE_TIME_CHECKS = -Wall -Wextra -Wformat=2 -Wconversion -Wsign-conversion -Wtrampolines -Werror
+RUN_TIME_CHECKS = -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fPIE -pie
+CFLAGS = $(COMPILE_TIME_CHECKS) $(RUN_TIME_CHECKS)
 all:
-	gcc -lX11 -pthread -g mouse.c
+	$(CC) $(CFLAGS) -lX11 -pthread -g mouse.c

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 CC = gcc
 COMPILE_TIME_CHECKS = -Wall -Wextra -Wformat=2 -Wconversion -Wsign-conversion -Wtrampolines -Werror
-RUN_TIME_CHECKS = -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fPIE -pie
+RUN_TIME_CHECKS = -D_FORTIFY_SOURCE=3 -O2 -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fPIE -pie
 CFLAGS = $(COMPILE_TIME_CHECKS) $(RUN_TIME_CHECKS)
 all:
-	$(CC) $(CFLAGS) -lX11 -pthread -g mouse.c
+	$(CC) $(CFLAGS) -lX11 -pthread mouse.c
+
+debug:
+	$(CC) -lX11 -pthread -g mouse.c
+
+clean:
+ifneq (,$(wildcard ./a.out))
+	rm ./a.out
+endif

--- a/mouse.c
+++ b/mouse.c
@@ -41,12 +41,10 @@ void t_mmover(){
 
 }
 
-int main(int argc, char* argv[]){
+int main(){
   // call mouse mover function in new thread
   pthread_t tid;
-  pthread_create(&tid, NULL, (void * (*)(void *))t_mmover, NULL);
-
-
+  pthread_create(&tid, NULL, (void *)t_mmover, NULL);
   printf("press any key to quit\n");
   getc(stdin);             // wait for user interaction
   t_mmover_running = 0;    // stop main loop in thread

--- a/mouse.c
+++ b/mouse.c
@@ -41,7 +41,7 @@ void t_mmover(){
 
 }
 
-main(){
+int main(int argc, char* argv[]){
   // call mouse mover function in new thread
   pthread_t tid;
   pthread_create(&tid, NULL, (void * (*)(void *))t_mmover, NULL);

--- a/mouse.c
+++ b/mouse.c
@@ -21,7 +21,7 @@
 
 int t_mmover_running = 1;
 
-void t_mmover(){
+void* t_mmover(){
   // time structure used for nanosleep function
   struct timespec times;
   times.tv_sec=1;   // seconds to sleep
@@ -38,13 +38,13 @@ void t_mmover(){
     nanosleep(&times,NULL); // sleep thread
   }
   XCloseDisplay(display);   // finish and clean
-
+  return NULL;
 }
 
 int main(){
   // call mouse mover function in new thread
   pthread_t tid;
-  pthread_create(&tid, NULL, (void *)t_mmover, NULL);
+  pthread_create(&tid, NULL, (void* (*)(void*))t_mmover, NULL);
   printf("press any key to quit\n");
   getc(stdin);             // wait for user interaction
   t_mmover_running = 0;    // stop main loop in thread


### PR DESCRIPTION
- Added .gitignore for emacs backup files
- Makefile Updates
  - Added some Compiler Options to Harden the Binary based on [OpenSSF C/C++ Compiler Options Hardening Guide](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++)
  - Added some sanitizers as a Compiler Option
  - C Code is compliance with ISO C standards (-pedantic)
  - Added functionality to enable debug options
  - Added functionality to clean new binaries created